### PR TITLE
Strip trailing new line in .string files

### DIFF
--- a/maker.c
+++ b/maker.c
@@ -116,6 +116,13 @@ int main(int argc, char **argv) {
 				string = malloc(s + 1);
 				fread(string, s, 1, fs);
 				string[s] = '\0';
+				if (s > 0) {
+					--s;
+					// Strip trailing newlines
+					while (s >= 0 && string[s] == '\r' || string[s] == '\n') {
+						string[s--] = '\0';
+					}
+				}
 
 				fclose(fs);
 			}


### PR DESCRIPTION
When saving the .string files in a text editor that adds a trailing new line at the end of the file, that trailing newline is kept in the `s$` string as well (which might be what one wants, but usually not):

```
% hexdump -C payloads/boot-fifa.string
00000000  63 64 72 6f 6d 30 3a 5c  46 49 46 41 44 45 4d 4f  |cdrom0:\FIFADEMO|
00000010  5c 47 41 4d 45 5a 2e 45  4c 46 0a                 |\GAMEZ.ELF.|
0000001b
```

Resulting code:

```
% cat out/boot-fifa-95205.yab
# Run %lg -> %lu patch before this!

dim x(1,1073741825)
x(0,67108864)=144117395689242624.0
x(0,67108865)=6.0
x(0,67108866)=1.0

x(0,2510008)=550339984.0
s$="cdrom0:\FIFADEMO\GAMEZ.ELF
"
```